### PR TITLE
Fix session truncation bug

### DIFF
--- a/openaiHelper.js
+++ b/openaiHelper.js
@@ -58,7 +58,7 @@ export async function manageTokensAndGenerateResponse(userSession, msgText=null,
     }
 
     // Ensure system messages are preserved at the start of the session
-    if (userSession[0]?.role === "system") {
+    if (userSession[0]?.role === "system" && truncatedSession[0]?.role !== "system") {
         truncatedSession.unshift(userSession[0]);
     }
 
@@ -68,7 +68,7 @@ export async function manageTokensAndGenerateResponse(userSession, msgText=null,
         // Call the OpenAI API with the formatted messages
         const response = await openai.chat.completions.create({
             model: "gpt-4-vision-preview",
-            messages: userSession,
+            messages: truncatedSession,
             max_tokens: 4096
         });
         const gptResponse = response.choices[0].message;
@@ -105,4 +105,4 @@ export async function generateEmojiReaction(message, openai) {
     return reaction === "No Emoji" ? null : reaction;
 }
   
-  
+


### PR DESCRIPTION
## Summary
- fix token trimming in `openaiHelper` so OpenAI only receives the truncated session
- avoid duplicate system prompts
- clean stray text at end of file

## Testing
- `npm install`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683fee80587c832fb0aa48982ad8a5e2